### PR TITLE
Defense maintenance added

### DIFF
--- a/Assets/Prefabs/Structures/Defenses/Bomb.prefab
+++ b/Assets/Prefabs/Structures/Defenses/Bomb.prefab
@@ -140,7 +140,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   size: 1
-  health: 0
+  health: 100
   canLoseHealth: 0
   level: 0
   blockType: 0
@@ -150,5 +150,6 @@ MonoBehaviour:
   fireRate: 0
   damage: 40
   attackRange: 4
+  maintenanceCost: 5
   canBreakWorld: 1
   explosionParticles: {fileID: 4964779859338955144, guid: 8a2ab21b4543bb14ebee8f6ff1221879, type: 3}

--- a/Assets/Prefabs/Structures/Defenses/MountainDefense.prefab
+++ b/Assets/Prefabs/Structures/Defenses/MountainDefense.prefab
@@ -60,7 +60,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   size: 2
-  health: 0
+  health: 100
   canLoseHealth: 0
   level: 0
   blockType: 2
@@ -70,6 +70,7 @@ MonoBehaviour:
   fireRate: 5
   damage: 3
   attackRange: 8
+  maintenanceCost: 5
   firePoint: {fileID: 5475787786454904890}
   cannon: {fileID: 0}
   enemyTarget: {fileID: 0}

--- a/Assets/Prefabs/Structures/Defenses/Pesada.prefab
+++ b/Assets/Prefabs/Structures/Defenses/Pesada.prefab
@@ -172,7 +172,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   size: 2
-  health: 0
+  health: 100
   canLoseHealth: 0
   level: 0
   blockType: 1
@@ -182,6 +182,7 @@ MonoBehaviour:
   fireRate: 0.2
   damage: 30
   attackRange: 6
+  maintenanceCost: 5
   firePoint: {fileID: 4351021548220090795}
   cannon: {fileID: 4856589584197966362}
   enemyTarget: {fileID: 0}

--- a/Assets/Prefabs/Structures/Defenses/PsiquicDefense.prefab
+++ b/Assets/Prefabs/Structures/Defenses/PsiquicDefense.prefab
@@ -12,7 +12,6 @@ GameObject:
   - component: {fileID: 8766160501699570511}
   - component: {fileID: 3557293831074655906}
   - component: {fileID: 8006414575844936844}
-  - component: {fileID: 6388906839533808407}
   - component: {fileID: 8154688783917754508}
   m_Layer: 8
   m_Name: PsiquicDefense
@@ -99,35 +98,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1.3, y: 1.1, z: 1}
   m_Center: {x: 0.02, y: 0.55, z: 0.1}
---- !u!114 &6388906839533808407
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7137880238603071797}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3890934ac96f66841abdff0c0a54e5b5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  size: 2
-  health: 0
-  canLoseHealth: 0
-  level: 0
-  blockType: 1
-  structureName: psiquicTower
-  structureId: 1
-  canHitSkyEnemies: 0
-  fireRate: 0.3
-  damage: 3
-  attackRange: 4
-  firePoint: {fileID: 1127500018515762662}
-  cannon: {fileID: 0}
-  enemyTarget: {fileID: 0}
-  turnSpeed: 5
-  bulletPrefab: {fileID: 6002255402025451531, guid: b1c47069d5e3185409bff9c2183e8e8f, type: 3}
-  actualEffect: 1
 --- !u!114 &8154688783917754508
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -141,7 +111,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   size: 2
-  health: 0
+  health: 100
   canLoseHealth: 0
   level: 0
   blockType: 1
@@ -151,6 +121,7 @@ MonoBehaviour:
   fireRate: 0.3
   damage: 3
   attackRange: 5
+  maintenanceCost: 5
   particles: {fileID: 4964779859338955144, guid: ccc31fd69f4d6a842929870e848f5030, type: 3}
 --- !u!1 &8505893711344014288
 GameObject:

--- a/Assets/Prefabs/Structures/Defenses/ShootingDefense.prefab
+++ b/Assets/Prefabs/Structures/Defenses/ShootingDefense.prefab
@@ -111,7 +111,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   size: 2
-  health: 0
+  health: 100
   canLoseHealth: 0
   level: 0
   blockType: 1
@@ -121,6 +121,7 @@ MonoBehaviour:
   fireRate: 2
   damage: 14
   attackRange: 5
+  maintenanceCost: 5
   firePoint: {fileID: 1127500018515762662}
   cannon: {fileID: 0}
   enemyTarget: {fileID: 0}

--- a/Assets/Prefabs/VFXs/Particles/WaterSplashMaterial.mat
+++ b/Assets/Prefabs/VFXs/Particles/WaterSplashMaterial.mat
@@ -91,7 +91,7 @@ Material:
     - _ZWrite: 1
     m_Colors:
     - _CameraFadeParams: {r: 0, g: Infinity, b: 0, a: 0}
-    - _Color: {r: 0.82942134, g: 0.97902244, b: 0.98958486, a: 1}
+    - _Color: {r: 1, g: 0.9426719, b: 0.8316242, a: 1}
     - _ColorAddSubDiff: {r: 1, g: 0, b: 0, a: 0}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SoftParticleFadeParams: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -10658,16 +10658,19 @@ MonoBehaviour:
     upgradeMultiplicator: 1
     upgrades:
     - cost: 50
+      maintenanceCostIncrease: 5
       stats:
       - statToUpgrade: 0
         upgradeAddedValue: 2
     - cost: 100
+      maintenanceCostIncrease: 5
       stats:
       - statToUpgrade: 0
         upgradeAddedValue: 2
       - statToUpgrade: 2
         upgradeAddedValue: 1
     - cost: 150
+      maintenanceCostIncrease: 5
       stats:
       - statToUpgrade: 1
         upgradeAddedValue: 0.2
@@ -10680,16 +10683,19 @@ MonoBehaviour:
     upgradeMultiplicator: 1
     upgrades:
     - cost: 100
+      maintenanceCostIncrease: 5
       stats:
       - statToUpgrade: 0
         upgradeAddedValue: 2
     - cost: 150
+      maintenanceCostIncrease: 5
       stats:
       - statToUpgrade: 0
         upgradeAddedValue: 1
       - statToUpgrade: 2
         upgradeAddedValue: 1
     - cost: 200
+      maintenanceCostIncrease: 5
       stats:
       - statToUpgrade: 1
         upgradeAddedValue: 0.2
@@ -10702,14 +10708,17 @@ MonoBehaviour:
     upgradeMultiplicator: 1
     upgrades:
     - cost: 150
+      maintenanceCostIncrease: 5
       stats:
       - statToUpgrade: 0
         upgradeAddedValue: 5
     - cost: 200
+      maintenanceCostIncrease: 5
       stats:
       - statToUpgrade: 2
         upgradeAddedValue: 2
     - cost: 300
+      maintenanceCostIncrease: 5
       stats:
       - statToUpgrade: 1
         upgradeAddedValue: 0.1
@@ -10738,14 +10747,17 @@ MonoBehaviour:
     upgradeMultiplicator: 1
     upgrades:
     - cost: 75
+      maintenanceCostIncrease: 5
       stats:
       - statToUpgrade: 0
         upgradeAddedValue: 1
     - cost: 125
+      maintenanceCostIncrease: 5
       stats:
       - statToUpgrade: 2
         upgradeAddedValue: 1
     - cost: 200
+      maintenanceCostIncrease: 5
       stats:
       - statToUpgrade: 0
         upgradeAddedValue: 1

--- a/Assets/Scripts/Behaviours/Structures/Defenses/DefenseBehaviour.cs
+++ b/Assets/Scripts/Behaviours/Structures/Defenses/DefenseBehaviour.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -32,6 +33,13 @@ public abstract class DefenseBehaviour : Structure
     [Tooltip("The radius of the sphere in which the defense detects an enemy")]
     internal float attackRange = 5f;
 
+    [SerializeField]
+    [Tooltip("How much gold will be spent each second in keeping this defense active")]
+    protected int maintenanceCost = 5;
+    protected float maintenanceCountdown = 1f;
+    [SerializeField]
+    protected int healthPenalty = 5;
+
     public override void UpgradeStrucrure()
     {
 
@@ -54,6 +62,7 @@ public abstract class DefenseBehaviour : Structure
                         break;
                 }
             }
+            maintenanceCost += Blueprint.upgrades[level].maintenanceCostIncrease;
         }
         base.UpgradeStrucrure();
 
@@ -65,5 +74,37 @@ public abstract class DefenseBehaviour : Structure
         Gizmos.DrawWireSphere(transform.position, attackRange);
     }
 
+    private void FixedUpdate()
+    {
+        maintenanceCountdown -= Time.deltaTime;
+        if (maintenanceCountdown <=0f)
+        {
+            TowerMaintenance();
+            maintenanceCountdown = 1f;
+        }
+    }
 
+    private void TowerMaintenance()
+    {
+        if (!CheatManager.instance.infiniteMoney)
+        {
+            if (LevelStats.instance.currentMoney >= maintenanceCost)
+            {
+                LevelStats.instance.SpendMoney(maintenanceCost);
+            }
+            else
+            {
+                health -= healthPenalty;
+                if (health <= 0f)
+                {
+                    if (BuildManager.instance.SelectedStructure.gameObject == gameObject)
+                    {
+                        UIController.instance.SetUpgradeMenuActive(false);
+                    }
+                    Destroy(gameObject);
+                    
+                }
+            }
+        }
+    }
 }

--- a/Assets/Scripts/Systems/StructureBlueprint.cs
+++ b/Assets/Scripts/Systems/StructureBlueprint.cs
@@ -21,6 +21,7 @@ public class StructureBlueprint
 public class Upgrade
 {
     public int cost;
+    public int maintenanceCostIncrease;
     public Stats[] stats;
   
 }

--- a/Assets/Scripts/Systems/UIController.cs
+++ b/Assets/Scripts/Systems/UIController.cs
@@ -448,6 +448,11 @@ public class UIController : MonoBehaviour
         }
     }
 
+    public void SetUpgradeMenuActive(bool active)
+    {
+        upgradeMenu.SetActive(active);
+    }
+
     private void OnDestroy()
     {
         LevelManager.OnWaveCleared -= UpdateWaveText;


### PR DESCRIPTION
Now defenses consumes gold in order to stay alive, if there's not enough gold, defense's hp will get consumed instead. Also with each upgrade the maintenanceCost can be updated.

If the selectedStructure loses all hp, upgradeMenu will be set inactive